### PR TITLE
chore: Rename browser option to overrideBrowserslist

### DIFF
--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -3,7 +3,7 @@
 module.exports = function parse(options) {
     if (typeof options === 'string') {
         return {
-            browsers: options.replace(/\s*,\s*/g, ',').split(','),
+            overrideBrowserslist: options.replace(/\s*,\s*/g, ',').split(','),
         };
     }
 


### PR DESCRIPTION
See https://github.com/postcss/autoprefixer/issues/1216

Currently there is a notice added to the output:

```
  Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config 
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```

this PR solves this by changing the option key from browsers to overrideBrowserslist.